### PR TITLE
Cleaning up duplicate vertices and triangles

### DIFF
--- a/pandamesh/gmsh_mesher.py
+++ b/pandamesh/gmsh_mesher.py
@@ -510,13 +510,13 @@ class GmshMesher:
         """
         self._combine_fields()
         gmsh.model.mesh.generate(dim=2)
-        
+
         # cleaning up of mesh in order to obtain unique elements and nodes
         gmsh.model.mesh.removeDuplicateElements()
         gmsh.model.mesh.removeDuplicateNodes()
         gmsh.model.mesh.renumberElements()
-        gmsh.model.mesh.renumberNodes()      
-                
+        gmsh.model.mesh.renumberNodes()
+
         return self._vertices(), self._faces()
 
     def generate_ugrid(self) -> "xugrid.Ugrid2d":  # type: ignore # noqa

--- a/pandamesh/gmsh_mesher.py
+++ b/pandamesh/gmsh_mesher.py
@@ -510,6 +510,13 @@ class GmshMesher:
         """
         self._combine_fields()
         gmsh.model.mesh.generate(dim=2)
+        
+        # cleaning up of mesh in order to obtain unique elements and nodes
+        gmsh.model.mesh.removeDuplicateElements()
+        gmsh.model.mesh.removeDuplicateNodes()
+        gmsh.model.mesh.renumberElements()
+        gmsh.model.mesh.renumberNodes()      
+                
         return self._vertices(), self._faces()
 
     def generate_ugrid(self) -> "xugrid.Ugrid2d":  # type: ignore # noqa


### PR DESCRIPTION
In my postprocessing the duplicate nodes caused difficulties (compared to the Triangle Mesher which has unique vertices and triangles). These few lines clean the data.

In my experience, the 'trick' with the donut as you show in the examples is not even necessary to add. I obtain valid meshes with overlapping polygons.